### PR TITLE
- added case to derive project id from client

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,6 +196,10 @@ function transformTogglTimeEntryData(timeEntryData, togglBaseData) {
   if (!clientId && projectId) {
     clientId = (_.findWhere(matchingClients, { id: _.findWhere(matchingProjects, { id: projectId }).cid }) || {}).id;
   }
+    
+  if (!projectId && clientId) {
+    projectId = (_.findWhere(matchingProjects, { cid: clientId }) || {}).id;
+  }
 
   if (!workspaceId && clientId) {
     workspaceId = (_.findWhere(matchingWorkspaces, { id: _.findWhere(matchingClients,  { id: clientId  }).wid }) || {}).id;


### PR DESCRIPTION
If there are multiple projects with the same name for different clients, the project ID is now resolved based on the client. 